### PR TITLE
(RE-12966) Removing pe-console-auth-ui from the FOSSA scanned repo list

### DIFF
--- a/ci/repo_list
+++ b/ci/repo_list
@@ -1,5 +1,4 @@
 #git@github.com:puppetlabs/pe-console-ui.git
-#git@github.com:puppetlabs/pe-console-auth-ui.git
 git@github.com:puppetlabs/analytics-client.git
 git@github.com:puppetlabs/analytics.git
 git@github.com:puppetlabs/bouncer-validators.git


### PR DESCRIPTION
Per https://github.com/puppetlabs/pe-console-auth-ui

    for 2019.1.x and forward, this repository is obsolete as pe-console-auth-ui
    has been merged with pe-console-ui