### PR TITLE
(maint) Add markdown generation for pe component licenses

### DIFF
--- a/component-licenses.md.erb
+++ b/component-licenses.md.erb
@@ -1,0 +1,144 @@
+---
+title: Component Licenses for Puppet Enterprise <version>
+---
+<h4>License Key</h4>
+
+<table id="license-key">
+
+<tbody>
+
+<tr>
+<td>Artistic 1.0</td>
+<td><a href="http://opensource.org/licenses/Artistic-1.0">http://opensource.org/licenses/Artistic-1.0</a></td>
+</tr>
+
+<tr>
+<td>Artistic 2.0</td>
+<td><a href="http://opensource.org/licenses/Artistic-2.0">http://opensource.org/licenses/Artistic-2.0</a></td>
+</tr>
+
+<tr>
+<td>Apache 2.0</td>
+<td><a href="http://www.apache.org/licenses/LICENSE-2.0.html">http://www.apache.org/licenses/LICENSE-2.0.html</a></td>
+</tr>
+
+<tr>
+<td>Boost Software License 1.0</td>
+<td><a href="http://www.boost.org/LICENSE_1_0.txt">http://www.boost.org/LICENSE_1_0.txt</a></td>
+</tr>
+
+<tr>
+<td>EDL 1.0</td>
+<td><a href="http://www.eclipse.org/org/documents/edl-v10.php">http://www.eclipse.org/org/documents/edl-v10.php</a></td>
+</tr>
+
+<tr>
+<td>EPL 1.0</td>
+<td><a href="http://opensource.org/licenses/eclipse-1.0.php">http://opensource.org/licenses/eclipse-1.0.php</a></td>
+</tr>
+
+<tr>
+<td>GPLv2</td>
+<td><a href="http://www.gnu.org/licenses/gpl-2.0.html">http://www.gnu.org/licenses/gpl-2.0.html</a></td>
+</tr>
+
+<tr>
+<td>GPLv2 (Classpath Exception)</td>
+<td><a href="http://openjdk.java.net/legal/gplv2+ce.html">http://openjdk.java.net/legal/gplv2+ce.html</a></td>
+</tr>
+
+<tr>
+<td>GPLv3</td>
+<td><a href="http://www.gnu.org/licenses/gpl-3.0.html">http://www.gnu.org/licenses/gpl-3.0.html</a></td>
+</tr>
+
+<tr>
+<td>ISC</td>
+<td><a href="http://opensource.org/licenses/isc-license.txt">http://opensource.org/licenses/isc-license.txt</a></td>
+</tr>
+
+<tr>
+<td>LGPL</td>
+<td><a href="http://www.gnu.org/licenses/lgpl.html">http://www.gnu.org/licenses/lgpl.html</a></td>
+</tr>
+
+<tr>
+<td>LGPLv3</td>
+<td><a href="http://opensource.org/licenses/lgpl-3.0.html">http://opensource.org/licenses/lgpl-3.0.html</a></td>
+</tr>
+
+<tr>
+<td>MIT</td>
+<td><a href="http://www.opensource.org/licenses/mit-license.php">http://www.opensource.org/licenses/mit-license.php</a></td>
+</tr>
+
+<tr>
+<td>MPL 2.0</td>
+<td><a href="http://opensource.org/licenses/MPL-2.0">http://opensource.org/licenses/MPL-2.0</a></td>
+</tr>
+
+<tr>
+<td>OpenSSL and SSLeay</td>
+<td><a href="https://www.openssl.org/source/license.html">https://www.openssl.org/source/license.html</a></td>
+</tr>
+
+<tr>
+<td>PostgreSQL</td>
+<td><a href="http://www.opensource.org/licenses/postgresql">http://www.opensource.org/licenses/postgresql</a></td>
+</tr>
+
+<tr>
+<td>Ruby</td>
+<td><a href="http://www.ruby-lang.org/en/LICENSE.txt">http://www.ruby-lang.org/en/LICENSE.txt</a></td>
+</tr>
+
+<tr>
+<td>BSD (2 clause)</td>
+<td><a href="https://opensource.org/licenses/BSD-2-Clause">https://opensource.org/licenses/BSD-2-Clause</a></td>
+</tr>
+
+<tr>
+<td>BSD (3 clause)</td>
+<td><a href="https://opensource.org/licenses/BSD-3-Clause">https://opensource.org/licenses/BSD-3-Clause</a></td>
+</tr>
+
+<tr>
+<td>UNICODE, INC. LICENSE AGREEMENT</td>
+<td><a href="https://unicode.org/copyright.html">https://unicode.org/copyright.html</a></td>
+</tr>
+
+</tbody>
+</table>
+
+<h3>Puppet Enterprise Third Party Components Licenses</h3>
+
+
+<h4>Enterprise Console</h4>
+<table id="Enterprise Console">
+
+<table>
+  <thead>
+    <tr>
+      <th>OS</th>
+      <th>Arch</th>
+      <th>Link</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    
+<% package_data.each do |package| -%>
+<tr>
+<% package.each_with_index do |package_field, index| -%>
+<% if index == 4 -%>
+<td><a href="<%= package_field %>"><%= package_field -%></a></td>
+<% else -%>
+<td><%= package_field -%></td>
+<% end -%>
+<% end %>
+</tr>
+<% end %>
+  
+  </tbody>
+
+</table>

--- a/generate-markdown-page
+++ b/generate-markdown-page
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+
+require 'csv'
+require 'erb'
+require 'optparse'
+
+ERB_TEMPLATE_FILE_NAME = "component-licenses.md.erb"
+
+script = File.basename($0)
+
+license_csv_file = ARGV.shift
+
+if license_csv_file.nil?
+  puts "Error: Usage: #{script} <fossa_csv_file>"
+  exit 1
+end
+
+unless FileTest.readable?(license_csv_file)
+  puts "#{script}: Error: Cannot read CSV file \"#{license_csv_file}\"."
+  exit 1
+end
+
+erb_template = File.read(ERB_TEMPLATE_FILE_NAME)
+erb_renderer = ERB.new(erb_template, nil, '-')
+erb_renderer.filename = ERB_TEMPLATE_FILE_NAME
+
+# Read the license CSV files, throw out any empty entries, sort by package name
+package_data = CSV.read(license_csv_file)
+                 .reject { |line| line.length == 0 }
+                 .sort { |a, b| a[0] <=> b[0] }
+
+puts erb_renderer.result(binding)


### PR DESCRIPTION
see https://github.com/puppetlabs/puppet-com-release-pages/pull/48

someone with better knowledge on spacing/tabbing lmk if things need to be moved, in general markdown seems to want everything on the left side w/o tabs