### PR TITLE
Update build

### DIFF
--- a/ci/build
+++ b/ci/build
@@ -17,7 +17,7 @@ export GEM_SOURCE=https://artifactory.delivery.puppetlabs.net/artifactory/api/ge
 git clean -ffdx
 
 source /usr/local/rvm/scripts/rvm
-rvm use 2.7.1
+rvm use 2.7.5
 
 set -x
 


### PR DESCRIPTION
DIO-2951 use refreshed ruby versions
the minimum patch level for 2.7 is 2.7.5 in the k8s-worker universal image